### PR TITLE
TOBI-102: Haneke Crash

### DIFF
--- a/Haneke/Format.swift
+++ b/Haneke/Format.swift
@@ -93,6 +93,8 @@ public struct ImageResizer {
         
         if let resizedImage = image.hnk_imageByScaling(toSize: resizeToSize) {
             return resizedImage
+        } else {
+            assertionFailure("Expected non-nil value for resized image")
         }
         
         return image

--- a/Haneke/Format.swift
+++ b/Haneke/Format.swift
@@ -87,7 +87,10 @@ public struct ImageResizer {
             return image
         }
         
-        let resizedImage = image.hnk_imageByScaling(toSize: resizeToSize)
-        return resizedImage
+        if let resizedImage = image.hnk_imageByScaling(toSize: resizeToSize) {
+            return resizedImage
+        }
+        
+        return image
     }
 }

--- a/Haneke/Format.swift
+++ b/Haneke/Format.swift
@@ -62,18 +62,22 @@ public struct ImageResizer {
     }
     
     public func resizeImage(_ image: UIImage) -> UIImage {
+        // Make sure we have non-zero size
+        guard size.width > 0, size.height > 0, image.size.width > 0, image.size.height > 0 else {
+            return image
+        }
+        
         var resizeToSize: CGSize
-        switch self.scaleMode {
+        switch scaleMode {
         case .Fill:
-            resizeToSize = self.size
+            resizeToSize = size
         case .AspectFit:
-            resizeToSize = image.size.hnk_aspectFitSize(self.size)
+            resizeToSize = image.size.hnk_aspectFitSize(size)
         case .AspectFill:
-            resizeToSize = image.size.hnk_aspectFillSize(self.size)
+            resizeToSize = image.size.hnk_aspectFillSize(size)
         case .None:
             return image
         }
-        assert(self.size.width > 0 && self.size.height > 0, "Expected non-zero size. Use ScaleMode.None to avoid resizing.")
         
         // If does not allow to scale up the image
         if (!self.allowUpscaling) {

--- a/Haneke/UIImage+Haneke.swift
+++ b/Haneke/UIImage+Haneke.swift
@@ -10,12 +10,12 @@ import UIKit
 
 extension UIImage {
 
-    func hnk_imageByScaling(toSize size: CGSize) -> UIImage {
+    func hnk_imageByScaling(toSize size: CGSize) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(size, !hnk_hasAlpha(), 0.0)
         draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
         let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        return resizedImage!
+        return resizedImage
     }
 
     func hnk_hasAlpha() -> Bool {

--- a/HanekeDemo/AppDelegate.swift
+++ b/HanekeDemo/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }


### PR DESCRIPTION
_**What's this PR about?**_
**Backstory**: 
Haneke sometimes crashes when trying to resize image.

 **Problem**: 
As Fabric logs imply crash is caused when forcing to unwrap optional value.

 **Verdict**: 
Optional value must be unwrapped in the safe way.

**Resolution**:
Method `hnk_imageByScaling(toSize:)` is changed to return optional value and in method `resizeImage(_ image)` this optional value is being unwrapped in the safe way.

_Bug raised in Jira board_: 
https://poqcommerce.atlassian.net/browse/TOBI-102
